### PR TITLE
🛠️ modify(#27): user 테이블에서 name column drop 및 구글 userInfo 수정

### DIFF
--- a/prisma/migrations/20240830080410_del_user_name_column/migration.sql
+++ b/prisma/migrations/20240830080410_del_user_name_column/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `name` on the `user` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "user_name_key";
+
+-- AlterTable
+ALTER TABLE "user" DROP COLUMN "name";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,8 +17,6 @@ datasource db {
 model User {
   /// Primary Key
   id        Int       @id @default(autoincrement())
-  /// 실명 이름
-  name      String    @unique @db.VarChar(20)
   /// 닉네임
   nickname  String    @unique @db.VarChar(20)
   /// 이메일

--- a/src/api/auth/auth-provider-config.ts
+++ b/src/api/auth/auth-provider-config.ts
@@ -28,7 +28,6 @@ export function createAuthProviderConfig() {
       }),
       extractUserInfo: (userInfoResponse: any) => ({
         uniqueId: userInfoResponse.response.id,
-        name: userInfoResponse.response.name,
         nickname: userInfoResponse.response.nickname,
         email: userInfoResponse.response.email,
         phone: userInfoResponse.response.mobile,
@@ -51,9 +50,9 @@ export function createAuthProviderConfig() {
         Authorization: `Bearer ${socialAccessToken}`
       }),
       extractUserInfo: (userInfoResponse: any) => ({
-        name: userInfoResponse.response.name,
-        email: userInfoResponse.response.email,
         uniqueId: userInfoResponse.response.id,
+        nickname: userInfoResponse.response.name,
+        email: userInfoResponse.response.email,
         provider: UserProvider.KAKAO
       })
     },
@@ -74,9 +73,9 @@ export function createAuthProviderConfig() {
         Authorization: `Bearer ${socialAccessToken}`
       }),
       extractUserInfo: (userInfoResponse: any) => ({
-        uniqueId: userInfoResponse.response.id,
-        name: userInfoResponse.response.name,
-        email: userInfoResponse.response.email,
+        uniqueId: userInfoResponse.id,
+        nickname: userInfoResponse.name,
+        email: userInfoResponse.email,
         provider: UserProvider.GOOGLE
       })
     }


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
user 테이블에서 `name` 칼럼을 삭제했습니다.
구글 oauth에선 실명 제공을 안하기도 하고 딱히 실명을 사용하지 않아서 추후 검수를 원활하게 하기 위해서 삭제합니다.

구글 로그인 테스트 완료했고, 구글 extractUserInfo 함수에서 유저 정보를 가져오는 경로를 수정했습니다.
<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#27 

<!-- 작업한 API (선택) -->
### API

| Method | Path      | 설명           | 작업(추가, 수정, 삭제) |
| ------ | --------- | -------------- | ---------------------- |
| POST   | /api/auth/:provider/login | oauth 로그인 | 수정                   |
