### PR TITLE
🛠️ modify(#29): fancy, fancy_stock 스키마 수정

### DIFF
--- a/prisma/migrations/20240902045114_modify_fancy_and_fancy_stock_option/migration.sql
+++ b/prisma/migrations/20240902045114_modify_fancy_and_fancy_stock_option/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `default_display` on the `fancy` table. All the data in the column will be lost.
+  - The `option` column on the `order_item` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterTable
+ALTER TABLE "fancy" DROP COLUMN "default_display";
+
+-- AlterTable
+ALTER TABLE "fancy_stock" ADD COLUMN     "option" VARCHAR(255)[];
+
+-- AlterTable
+ALTER TABLE "order_item" DROP COLUMN "option",
+ADD COLUMN     "option" VARCHAR(255)[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,15 +47,15 @@ model User {
   @@map("user")
 }
 
-/// 유저 소셜 토큰 테이블
+/// 유저 토큰 테이블
 model UserToken {
   /// Primary Key
   id                 Int      @id @default(autoincrement())
   /// 유저 아이디 (FK)
   userId             Int      @unique @map("user_id")
-  /// 액세스 토큰
+  /// 소셜 액세스 토큰
   socialAccessToken  String   @unique @map("social_access_token") @db.VarChar(255)
-  /// 리프레시 토큰
+  /// 소셜 리프레시 토큰
   socialRefreshToken String   @unique @map("social_refresh_token") @db.VarChar(255)
   /// 생성일
   createdAt          DateTime @default(now()) @map("created_at") @db.Timestamp
@@ -99,27 +99,25 @@ model Address {
 // 완제품 테이블
 model Fancy {
   /// Primary Key
-  id             String        @id @db.VarChar(50)
+  id           String        @id @db.VarChar(50)
   /// 상품명
-  name           String        @unique @db.VarChar(100)
+  name         String        @unique @db.VarChar(100)
   /// 원가
-  costPrice      Int           @map("cost_price") @db.Integer
+  costPrice    Int           @map("cost_price") @db.Integer
   /// 판매가
-  price          Int           @db.Integer
+  price        Int           @db.Integer
   /// 할인율
-  discountRate   Int           @default(0) @map("discount_rate") @db.SmallInt
+  discountRate Int           @default(0) @map("discount_rate") @db.SmallInt
   /// 설명1
-  description1   String?       @db.Text
+  description1 String?       @db.Text
   /// 설명2
-  description2   String?       @db.Text
+  description2 String?       @db.Text
   /// 상태
-  status         ProductStatus @default(INACTIVE)
-  /// 기본 제품 여부
-  defaultDisplay Boolean       @default(false) @map("default_display") @db.Boolean
+  status       ProductStatus @default(INACTIVE)
   /// 생성일
-  createdAt      DateTime      @default(now()) @map("created_at") @db.Timestamp
+  createdAt    DateTime      @default(now()) @map("created_at") @db.Timestamp
   /// 수정일
-  updatedAt      DateTime      @updatedAt @map("updated_at") @db.Timestamp
+  updatedAt    DateTime      @updatedAt @map("updated_at") @db.Timestamp
 
   fancyImages     FancyImage[]
   fancyStocks     FancyStock[]
@@ -158,6 +156,8 @@ model FancyStock {
   fancyId   String   @map("fancy_id")
   /// 재고량
   quantity  Int      @default(0) @db.SmallInt
+  /// 옵션
+  option    String[] @db.VarChar(255)
   /// 생성일
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamp
 
@@ -317,7 +317,7 @@ model FancyOrderItem {
   /// 수량
   quantity  Int       @db.SmallInt
   /// 옵션
-  option    String?   @db.VarChar(255)
+  option    String[]  @db.VarChar(255)
   /// 가격
   price     Int       @db.Integer
   /// 포장 방식


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
기존에 fancy에 옵션이 들어간 상태로 uuid를 만들어서 완제품을 관리하려고 했으나,
옵션은 제외하고 따로 관리하는 것이 좋을거 같아서 수정합니다.

fancy(완제품) 테이블에서 `defaultDisplay`(기본 제품 여부) 칼럼을 삭제했습니다.

fnacy_stock(완제품 재고) 테이블에 `option` 칼럼을 추가했습니다.
<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#29 
