### PR TITLE
📃 doc(#32): auth 컨트롤러 swagger 문서 작업

### DIFF
--- a/src/api/auth/controllers/auth.controller.ts
+++ b/src/api/auth/controllers/auth.controller.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
+import { ApiAuth } from '@src/api/auth/controllers/auth.swagger';
 import { ServiceTokenDto } from '@src/api/auth/dtos/service-token.dto';
 import { RefreshTokenAuthGuard } from '@src/api/auth/jwt/jwt-auth.guard';
 import { AuthService } from '@src/api/auth/services/auth.service';
@@ -17,21 +18,24 @@ import { IAuthService } from '@src/api/auth/services/i-auth-service.interface';
 import { LoginParamDto } from '@src/api/users/dtos/login.dto';
 import { GetUserId } from '@src/common/decorators/get-userId.decorator';
 import { CookieInterceptor } from '@src/common/interceptors/cookie.interceptor';
+import { ExistsPipe } from '@src/common/pipes/exists.pipe';
 
 @ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(@Inject(AuthService) private readonly authService: IAuthService) {}
 
+  @ApiAuth.Login({ summary: '소셜 로그인' })
   @UseInterceptors(CookieInterceptor)
   @Post(':provider/login')
   login(
     @Param() param: LoginParamDto,
-    @Query('code') authorizeCode: string
+    @Query('code', ExistsPipe) authorizeCode: string
   ): Promise<ServiceTokenDto> {
     return this.authService.login(param.provider, authorizeCode);
   }
 
+  @ApiAuth.GetNewAccessToken({ summary: '새 액세스 토큰 발급' })
   @UseInterceptors(CookieInterceptor)
   @UseGuards(RefreshTokenAuthGuard)
   @Get('new-access-token')

--- a/src/api/auth/controllers/auth.swagger.ts
+++ b/src/api/auth/controllers/auth.swagger.ts
@@ -3,7 +3,6 @@ import {
   ApiBadRequestResponse,
   ApiCookieAuth,
   ApiCreatedResponse,
-  ApiHeader,
   ApiInternalServerErrorResponse,
   ApiOkResponse,
   ApiOperation,

--- a/src/api/auth/controllers/auth.swagger.ts
+++ b/src/api/auth/controllers/auth.swagger.ts
@@ -1,13 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import {
-  ApiBadRequestResponse,
-  ApiCookieAuth,
-  ApiCreatedResponse,
-  ApiInternalServerErrorResponse,
-  ApiOkResponse,
-  ApiOperation,
-  ApiResponse
-} from '@nestjs/swagger';
+import { ApiCookieAuth, ApiOperation, ApiParam, ApiQuery, ApiResponse } from '@nestjs/swagger';
 
 import { AuthController } from '@src/api/auth/controllers/auth.controller';
 import { ApiOperationOptionsWithSummary, ApiOperator } from '@src/common/types/common.type';
@@ -18,7 +10,8 @@ export const ApiAuth: ApiOperator<keyof AuthController> = {
       ApiOperation({
         ...apiOperationOptions
       }),
-      ApiCreatedResponse({
+      ApiResponse({
+        status: 201,
         description: '로그인 성공. (쿠키에 accessToken, refreshToken 저장)',
         schema: {
           type: 'object',
@@ -36,7 +29,8 @@ export const ApiAuth: ApiOperator<keyof AuthController> = {
           }
         }
       }),
-      ApiBadRequestResponse({
+      ApiResponse({
+        status: 400,
         description: '로그인 요청 시 인가코드가 누락됨.',
         schema: {
           type: 'object',
@@ -60,7 +54,8 @@ export const ApiAuth: ApiOperator<keyof AuthController> = {
           }
         }
       }),
-      ApiInternalServerErrorResponse({
+      ApiResponse({
+        status: 500,
         description: '로그인 중 에러 발생.',
         schema: {
           type: 'object',
@@ -83,6 +78,18 @@ export const ApiAuth: ApiOperator<keyof AuthController> = {
             }
           }
         }
+      }),
+      ApiParam({
+        name: 'provider',
+        type: 'string',
+        required: true,
+        description: '로그인 제공자 (ex: naver, kakao, google)'
+      }),
+      ApiQuery({
+        name: 'code',
+        type: 'string',
+        required: true,
+        description: '소셜 로그인 인가코드'
       })
     );
   },
@@ -92,7 +99,8 @@ export const ApiAuth: ApiOperator<keyof AuthController> = {
       ApiOperation({
         ...apiOperationOptions
       }),
-      ApiOkResponse({
+      ApiResponse({
+        status: 200,
         description: '새 accessToken 발급 성공. (쿠키에 accessToken 저장)',
         schema: {
           type: 'object',
@@ -157,6 +165,15 @@ export const ApiAuth: ApiOperator<keyof AuthController> = {
                 },
                 description: '우리 서비스의 토큰이 아닌 경우'
               },
+              'token missmatch': {
+                value: {
+                  statusCode: 401,
+                  timestamp: '2024-09-04T04:45:55.410Z',
+                  path: '/api/auth/new-access-token',
+                  message: 'token missmatch'
+                },
+                description: '토큰이 일치하지 않는 경우'
+              },
               'jwt expired': {
                 value: {
                   statusCode: 401,
@@ -170,7 +187,8 @@ export const ApiAuth: ApiOperator<keyof AuthController> = {
           }
         }
       }),
-      ApiInternalServerErrorResponse({
+      ApiResponse({
+        status: 500,
         description: '새 accessToken 발급 중 에러 발생.',
         schema: {
           type: 'object',

--- a/src/api/auth/controllers/auth.swagger.ts
+++ b/src/api/auth/controllers/auth.swagger.ts
@@ -1,0 +1,201 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiCookieAuth,
+  ApiCreatedResponse,
+  ApiHeader,
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiResponse
+} from '@nestjs/swagger';
+
+import { AuthController } from '@src/api/auth/controllers/auth.controller';
+import { ApiOperationOptionsWithSummary, ApiOperator } from '@src/common/types/common.type';
+
+export const ApiAuth: ApiOperator<keyof AuthController> = {
+  Login: (apiOperationOptions: ApiOperationOptionsWithSummary): PropertyDecorator => {
+    return applyDecorators(
+      ApiOperation({
+        ...apiOperationOptions
+      }),
+      ApiCreatedResponse({
+        description: '로그인 성공. (쿠키에 accessToken, refreshToken 저장)',
+        schema: {
+          type: 'object',
+          properties: {
+            accessToken: {
+              type: 'string',
+              example:
+                'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhY2Nlc3NUb2tlbiIsInVzZXJJZCI6MiwiaWF0IjoxNzI1NDE3NDAxLCJleHAiOjE3MjU1MDM4MDF9.PV3OP9jsZxBV75p4SxkypRl0fil_OCfm9OA6MT4n9cI'
+            },
+            refreshToken: {
+              type: 'string',
+              example:
+                'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyZWZyZXNoVG9rZW4iLCJ1c2VySWQiOjIsImlhdCI6MTcyNTQxNzQwMSwiZXhwIjoxNzI2MDIyMjAxfQ.8q-UrxPk-CuQswqXemufvl6Tb0I_lMWhEkztlxBOxF4'
+            }
+          }
+        }
+      }),
+      ApiBadRequestResponse({
+        description: '로그인 요청 시 인가코드가 누락됨.',
+        schema: {
+          type: 'object',
+          properties: {
+            statusCode: {
+              type: 'number',
+              example: 400
+            },
+            timestamp: {
+              type: 'string',
+              example: '2024-09-04T04:45:55.410Z'
+            },
+            path: {
+              type: 'string',
+              example: '/api/auth/:provider/login'
+            },
+            message: {
+              type: 'string',
+              example: 'The code is required for query.'
+            }
+          }
+        }
+      }),
+      ApiInternalServerErrorResponse({
+        description: '로그인 중 에러 발생.',
+        schema: {
+          type: 'object',
+          properties: {
+            statusCode: {
+              type: 'number',
+              example: 500
+            },
+            timestamp: {
+              type: 'string',
+              example: '2024-09-04T04:10:34.008Z'
+            },
+            path: {
+              type: 'string',
+              example: '/api/auth/:provider/login'
+            },
+            message: {
+              type: 'string',
+              example: 'Failed to login'
+            }
+          }
+        }
+      })
+    );
+  },
+
+  GetNewAccessToken: (apiOperationOptions: ApiOperationOptionsWithSummary): PropertyDecorator => {
+    return applyDecorators(
+      ApiOperation({
+        ...apiOperationOptions
+      }),
+      ApiOkResponse({
+        description: '새 accessToken 발급 성공. (쿠키에 accessToken 저장)',
+        schema: {
+          type: 'object',
+          properties: {
+            accessToken: {
+              type: 'string',
+              example:
+                'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhY2Nlc3NUb2tlbiIsInVzZXJJZCI6MiwiaWF0IjoxNzI1NDE3NDAxLCJleHAiOjE3MjU1MDM4MDF9.PV3OP9jsZxBV75p4SxkypRl0fil_OCfm9OA6MT4n9cI'
+            }
+          }
+        }
+      }),
+      ApiResponse({
+        status: 400,
+        description: 'BadRequest',
+        content: {
+          'application/json': {
+            examples: {
+              'invalid token': {
+                value: {
+                  statusCode: 400,
+                  timestamp: '2024-09-04T04:45:55.410Z',
+                  path: '/api/auth/new-access-token',
+                  message: 'invalid token'
+                },
+                description: '유효하지 않은 토큰인 경우'
+              },
+              'jwt must be provided': {
+                value: {
+                  statusCode: 400,
+                  timestamp: '2024-09-04T04:45:55.410Z',
+                  path: '/api/auth/new-access-token',
+                  message: 'jwt must be provided'
+                },
+                description: '토큰이 제공되지 않은 경우'
+              },
+              'jwt error': {
+                value: {
+                  statusCode: 400,
+                  timestamp: '2024-09-04T04:45:55.410Z',
+                  path: '/api/auth/new-access-token',
+                  message: 'jwt error'
+                },
+                description: '그 외 에러 (백엔드에 도움 요청하기)'
+              }
+            }
+          }
+        }
+      }),
+      ApiResponse({
+        status: 401,
+        description: 'Unauthorized',
+        content: {
+          'application/json': {
+            examples: {
+              'invalid signature': {
+                value: {
+                  statusCode: 401,
+                  timestamp: '2024-09-04T04:45:55.410Z',
+                  path: '/api/auth/new-access-token',
+                  message: 'invalid signature'
+                },
+                description: '우리 서비스의 토큰이 아닌 경우'
+              },
+              'jwt expired': {
+                value: {
+                  statusCode: 401,
+                  timestamp: '2024-09-04T04:45:55.410Z',
+                  path: '/api/auth/new-access-token',
+                  message: 'jwt expired'
+                },
+                description: '만료된 토큰인 경우'
+              }
+            }
+          }
+        }
+      }),
+      ApiInternalServerErrorResponse({
+        description: '새 accessToken 발급 중 에러 발생.',
+        schema: {
+          type: 'object',
+          properties: {
+            statusCode: {
+              type: 'number',
+              example: 500
+            },
+            timestamp: {
+              type: 'string',
+              example: '2024-09-04T04:10:34.008Z'
+            },
+            path: {
+              type: 'string',
+              example: '/api/auth/new-access-token'
+            },
+            message: {
+              type: 'string',
+              example: 'Failed to generate new access token'
+            }
+          }
+        }
+      }),
+      ApiCookieAuth('refreshToken')
+    );
+  }
+};

--- a/src/bootstrap.service.ts
+++ b/src/bootstrap.service.ts
@@ -67,7 +67,28 @@ export class BootstrapService {
           `<a target="_black" href="${DOMAIN}/${YAML_PATH}">yaml document</a></br>`
       )
       .setVersion('0.1')
-      .addBearerAuth()
+      .addCookieAuth(
+        'accessToken',
+        {
+          type: 'http',
+          in: 'cookie',
+          name: 'accessToken',
+          scheme: 'bearer',
+          description: 'access token'
+        },
+        'accessToken'
+      )
+      .addCookieAuth(
+        'refreshToken',
+        {
+          type: 'http',
+          in: 'cookie',
+          name: 'refreshToken',
+          scheme: 'bearer',
+          description: 'refresh token'
+        },
+        'refreshToken'
+      )
       .build();
 
     const document = SwaggerModule.createDocument(app, config, {

--- a/src/bootstrap.service.ts
+++ b/src/bootstrap.service.ts
@@ -70,10 +70,9 @@ export class BootstrapService {
       .addCookieAuth(
         'accessToken',
         {
-          type: 'http',
+          type: 'apiKey',
           in: 'cookie',
           name: 'accessToken',
-          scheme: 'bearer',
           description: 'access token'
         },
         'accessToken'
@@ -81,10 +80,9 @@ export class BootstrapService {
       .addCookieAuth(
         'refreshToken',
         {
-          type: 'http',
+          type: 'apiKey',
           in: 'cookie',
           name: 'refreshToken',
-          scheme: 'bearer',
           description: 'refresh token'
         },
         'refreshToken'

--- a/src/common/pipes/exists.pipe.ts
+++ b/src/common/pipes/exists.pipe.ts
@@ -1,0 +1,14 @@
+import { ArgumentMetadata, HttpException, HttpStatus, PipeTransform } from '@nestjs/common';
+
+export class ExistsPipe implements PipeTransform {
+  async transform(value: string, metadata: ArgumentMetadata): Promise<string> {
+    if (!value) {
+      throw new HttpException(
+        `The ${metadata.data} is required for ${metadata.type}.`,
+        HttpStatus.BAD_REQUEST
+      );
+    }
+
+    return value;
+  }
+}


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
auth api swagger 문서 작업 완료했습니다.
<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
로그인 시에 인가코드 제공 여부를 판단하기 위해서 [`ExistsPipe`](https://github.com/fashion24-developer/fashion24-back/pull/33/files#diff-8d3c7bf27774e4800a2a15964d3978871771354ccfbe18db18e8d781a2ed2c80)를 추가했습니다.

토큰관련 에러 응답값은 다른 api에서 안써줘도 됩니다.

인증이 필요한 API의 swagger 파일에는 `ApiCookieAuth('accessToken')`, `ApiCookieAuth('refreshToken')` 형식으로 쿠키 auth를 설정해주시길 바랍니다.
###### 예시 참고 : [`auth.swagger.ts 197 line`](https://github.com/fashion24-developer/fashion24-back/pull/33/files#diff-0afaec0be74f2eb5da5d3762e7c2d03073d8cadd4d7853ba47b193a8f82c74f8R197)

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#32
