### PR TITLE
Api/#35/fancy create

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "cookie-signature": "^1.2.1",
         "inflection": "^3.0.0",
         "joi": "^17.13.3",
+        "nanoid": "^3.3.4",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1"
@@ -7159,6 +7160,17 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "cookie-signature": "^1.2.1",
     "inflection": "^3.0.0",
     "joi": "^17.13.3",
+    "nanoid": "^3.3.4",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1"

--- a/src/api/api.module.ts
+++ b/src/api/api.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 
 import { AuthModule } from '@src/api/auth/auth.module';
+import { FancyModule } from '@src/api/fancy/fancy.module';
 import { UsersModule } from '@src/api/users/users.module';
 
 @Module({
-  imports: [AuthModule, UsersModule]
+  imports: [AuthModule, UsersModule, FancyModule]
 })
 export class ApiModule {}

--- a/src/api/auth/controllers/auth.controller.ts
+++ b/src/api/auth/controllers/auth.controller.ts
@@ -39,7 +39,7 @@ export class AuthController {
   @UseInterceptors(CookieInterceptor)
   @UseGuards(RefreshTokenAuthGuard)
   @Get('new-access-token')
-  getNewAccessToken(@GetUserId() userId: number): ServiceTokenDto {
+  getNewAccessToken(@GetUserId() userId: number): Promise<ServiceTokenDto> {
     return this.authService.generateNewAccessToken(userId);
   }
 }

--- a/src/api/auth/dtos/token-payload.dto.ts
+++ b/src/api/auth/dtos/token-payload.dto.ts
@@ -3,5 +3,5 @@ import { TokenSubEnum } from '@src/api/auth/enums/token-sub.enum';
 export class TokenPayloadDto {
   sub: TokenSubEnum;
   userId: number;
-  userRole?: string;
+  userRole: string;
 }

--- a/src/api/auth/dtos/token-payload.dto.ts
+++ b/src/api/auth/dtos/token-payload.dto.ts
@@ -3,4 +3,5 @@ import { TokenSubEnum } from '@src/api/auth/enums/token-sub.enum';
 export class TokenPayloadDto {
   sub: TokenSubEnum;
   userId: number;
+  userRole?: string;
 }

--- a/src/api/auth/jwt/jwt-auth.guard.ts
+++ b/src/api/auth/jwt/jwt-auth.guard.ts
@@ -3,6 +3,8 @@ import { AuthGuard } from '@nestjs/passport';
 
 import { Observable } from 'rxjs';
 
+import { UserRole } from '@src/api/users/enums/user-role.enum';
+
 @Injectable()
 export class AccessTokenAuthGuard extends AuthGuard('accessToken') {
   canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
@@ -75,6 +77,46 @@ export class RefreshTokenAuthGuard extends AuthGuard('refreshToken') {
 
 @Injectable()
 export class AccessTokenOptionalAuthGuard extends AuthGuard('accessToken') {}
+
+@Injectable()
+export class AdminGuard extends AccessTokenAuthGuard {
+  canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const accessToken = request.cookies['accessToken'];
+    if (!accessToken) {
+      throw new HttpException('jwt must be provided', HttpStatus.BAD_REQUEST);
+    }
+
+    return super.canActivate(context);
+  }
+
+  handleRequest(
+    err: any,
+    user: any,
+    info: { message: string | Record<string, any> },
+    context: ExecutionContext
+  ) {
+    try {
+      if (user.userRole === UserRole.ADMIN) {
+        return super.handleRequest(err, user, info, context);
+      } else if (user.userRole !== UserRole.USER) {
+        throw new HttpException(
+          `You don't have permission to access this resource`,
+          HttpStatus.FORBIDDEN
+        );
+      }
+      if (err instanceof HttpException) throw err;
+
+      throw new HttpException(info.message, getStatus(info.message));
+    } catch (error) {
+      if (error instanceof HttpException) throw error;
+      else {
+        console.log(error.message);
+        throw new HttpException('jwt error', HttpStatus.BAD_REQUEST);
+      }
+    }
+  }
+}
 
 function getStatus(message: string | Record<string, any>): HttpStatus {
   switch (message) {

--- a/src/api/auth/jwt/jwt-auth.guard.ts
+++ b/src/api/auth/jwt/jwt-auth.guard.ts
@@ -79,7 +79,7 @@ export class RefreshTokenAuthGuard extends AuthGuard('refreshToken') {
 export class AccessTokenOptionalAuthGuard extends AuthGuard('accessToken') {}
 
 @Injectable()
-export class AdminGuard extends AccessTokenAuthGuard {
+export class AdminGuard extends AuthGuard('accessToken') {
   canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
     const request = context.switchToHttp().getRequest();
     const accessToken = request.cookies['accessToken'];

--- a/src/api/auth/services/auth.service.ts
+++ b/src/api/auth/services/auth.service.ts
@@ -46,11 +46,13 @@ export class AuthService implements IAuthService {
       // 서비스 토큰 발급
       const accessToken = this.tokenService.generateToken({
         sub: TokenSubEnum.ACCESS_TOKEN,
-        userId: user.id
+        userId: user.id,
+        userRole: user.role
       });
       const refreshToken = this.tokenService.generateToken({
         sub: TokenSubEnum.REFRESH_TOKEN,
-        userId: user.id
+        userId: user.id,
+        userRole: user.role
       });
 
       // 토큰 저장
@@ -71,11 +73,13 @@ export class AuthService implements IAuthService {
     }
   }
 
-  generateNewAccessToken(userId: number): ServiceTokenDto {
+  async generateNewAccessToken(userId: number): Promise<ServiceTokenDto> {
     try {
+      const user = await this.usersService.findOne({ where: { id: userId } });
       const accessToken = this.tokenService.generateToken({
         sub: TokenSubEnum.ACCESS_TOKEN,
-        userId
+        userId,
+        userRole: user.role
       });
 
       return { accessToken };

--- a/src/api/auth/services/i-auth-service.interface.ts
+++ b/src/api/auth/services/i-auth-service.interface.ts
@@ -3,5 +3,5 @@ import { UserProvider } from '@src/api/users/enums/user-provider.enum';
 
 export interface IAuthService {
   login(provider: UserProvider, authorizeCode: string): Promise<ServiceTokenDto>;
-  generateNewAccessToken(userId: number): ServiceTokenDto;
+  generateNewAccessToken(userId: number): Promise<ServiceTokenDto>;
 }

--- a/src/api/fancy/controllers/fancy.admin.controller.ts
+++ b/src/api/fancy/controllers/fancy.admin.controller.ts
@@ -8,9 +8,9 @@ import { CreateFancyDto } from '@src/api/fancy/dtos/create-fancy.dto';
 import { FancyService } from '@src/api/fancy/services/fancy.service';
 import { IFancyService } from '@src/api/fancy/services/i-fancy-service.interface';
 
-@ApiTags('fancy')
-@Controller('fancy')
-export class FancyController {
+@ApiTags('admin fancy')
+@Controller('admin/fancy')
+export class FancyAdminController {
   constructor(@Inject(FancyService) private readonly fancyService: IFancyService) {}
 
   @ApiFancy.Create({ summary: 'fancy 생성' })

--- a/src/api/fancy/controllers/fancy.admin.controller.ts
+++ b/src/api/fancy/controllers/fancy.admin.controller.ts
@@ -1,14 +1,16 @@
-import { Body, Controller, Inject, Post } from '@nestjs/common';
+import { Body, Controller, Inject, Post, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
 import { Fancy } from '@prisma/client';
 
+import { AdminGuard } from '@src/api/auth/jwt/jwt-auth.guard';
 import { ApiFancy } from '@src/api/fancy/controllers/fancy.swagger';
 import { CreateFancyDto } from '@src/api/fancy/dtos/create-fancy.dto';
 import { FancyService } from '@src/api/fancy/services/fancy.service';
 import { IFancyService } from '@src/api/fancy/services/i-fancy-service.interface';
 
 @ApiTags('admin fancy')
+@UseGuards(AdminGuard)
 @Controller('admin/fancy')
 export class FancyAdminController {
   constructor(@Inject(FancyService) private readonly fancyService: IFancyService) {}

--- a/src/api/fancy/controllers/fancy.controller.ts
+++ b/src/api/fancy/controllers/fancy.controller.ts
@@ -1,0 +1,17 @@
+import { Body, Controller, Inject, Post } from '@nestjs/common';
+
+import { Fancy } from '@prisma/client';
+
+import { CreateFancyDto } from '@src/api/fancy/dtos/create-fancy.dto';
+import { FancyService } from '@src/api/fancy/services/fancy.service';
+import { IFancyService } from '@src/api/fancy/services/i-fancy-service.interface';
+
+@Controller('fancy')
+export class FancyController {
+  constructor(@Inject(FancyService) private readonly fancyService: IFancyService) {}
+
+  @Post()
+  createFancy(@Body() fancyInfo: CreateFancyDto): Promise<Fancy> {
+    return this.fancyService.create(fancyInfo);
+  }
+}

--- a/src/api/fancy/controllers/fancy.controller.ts
+++ b/src/api/fancy/controllers/fancy.controller.ts
@@ -1,17 +1,21 @@
 import { Body, Controller, Inject, Post } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 
 import { Fancy } from '@prisma/client';
 
+import { ApiFancy } from '@src/api/fancy/controllers/fancy.swagger';
 import { CreateFancyDto } from '@src/api/fancy/dtos/create-fancy.dto';
 import { FancyService } from '@src/api/fancy/services/fancy.service';
 import { IFancyService } from '@src/api/fancy/services/i-fancy-service.interface';
 
+@ApiTags('fancy')
 @Controller('fancy')
 export class FancyController {
   constructor(@Inject(FancyService) private readonly fancyService: IFancyService) {}
 
+  @ApiFancy.Create({ summary: 'fancy 생성' })
   @Post()
-  createFancy(@Body() fancyInfo: CreateFancyDto): Promise<Fancy> {
+  create(@Body() fancyInfo: CreateFancyDto): Promise<Fancy> {
     return this.fancyService.create(fancyInfo);
   }
 }

--- a/src/api/fancy/controllers/fancy.swagger.ts
+++ b/src/api/fancy/controllers/fancy.swagger.ts
@@ -2,11 +2,11 @@ import { applyDecorators } from '@nestjs/common';
 import { ApiCookieAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { getSchemaPath } from '@nestjs/swagger';
 
-import { FancyController } from '@src/api/fancy/controllers/fancy.controller';
+import { FancyAdminController } from '@src/api/fancy/controllers/fancy.admin.controller';
 import { FancyDto } from '@src/api/fancy/dtos/fancy.dto';
 import { ApiOperationOptionsWithSummary, ApiOperator } from '@src/common/types/common.type';
 
-export const ApiFancy: ApiOperator<keyof FancyController> = {
+export const ApiFancy: ApiOperator<keyof FancyAdminController> = {
   Create: (apiOperationOptions: ApiOperationOptionsWithSummary): PropertyDecorator => {
     return applyDecorators(
       ApiOperation({

--- a/src/api/fancy/controllers/fancy.swagger.ts
+++ b/src/api/fancy/controllers/fancy.swagger.ts
@@ -1,5 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiCookieAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { getSchemaPath } from '@nestjs/swagger';
 
 import { FancyController } from '@src/api/fancy/controllers/fancy.controller';
@@ -96,7 +96,8 @@ export const ApiFancy: ApiOperator<keyof FancyController> = {
             }
           }
         }
-      })
+      }),
+      ApiCookieAuth('accessToken')
     );
   }
 };

--- a/src/api/fancy/controllers/fancy.swagger.ts
+++ b/src/api/fancy/controllers/fancy.swagger.ts
@@ -31,6 +31,71 @@ export const ApiFancy: ApiOperator<keyof FancyController> = {
           },
           $ref: getSchemaPath(FancyDto)
         }
+      }),
+      ApiResponse({
+        status: 400,
+        description: '필수 요청 값이 누락되었거나 잘못된 형식일 경우',
+        schema: {
+          type: 'object',
+          properties: {
+            statusCode: {
+              type: 'number',
+              example: 400
+            },
+            timestamp: {
+              type: 'string',
+              example: '2024-09-06T05:02:18.503Z'
+            },
+            path: {
+              type: 'string',
+              example: '/api/fancy'
+            },
+            message: {
+              type: 'object',
+              properties: {
+                message: {
+                  type: 'array',
+                  items: {
+                    type: 'string'
+                  },
+                  example: [
+                    'property status1 should not exist',
+                    'status must be one of the following values: ACTIVE, INACTIVE'
+                  ]
+                }
+              }
+            },
+            error: {
+              type: 'string',
+              example: 'Bad Request'
+            }
+          }
+        }
+      }),
+      ApiResponse({
+        status: 500,
+        description: 'Fancy 생성 실패',
+        schema: {
+          type: 'object',
+          properties: {
+            statusCode: {
+              type: 'number',
+              example: 500
+            },
+            timestamp: {
+              type: 'string',
+              example: '2024-09-06T05:02:18.503Z'
+            },
+            path: {
+              type: 'string',
+              example: '/api/fancy'
+            },
+            message: {
+              type: 'string',
+              example: 'Failed to create fancy'
+            }
+          }
+        }
       })
     );
   }

--- a/src/api/fancy/controllers/fancy.swagger.ts
+++ b/src/api/fancy/controllers/fancy.swagger.ts
@@ -1,0 +1,37 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { getSchemaPath } from '@nestjs/swagger';
+
+import { FancyController } from '@src/api/fancy/controllers/fancy.controller';
+import { FancyDto } from '@src/api/fancy/dtos/fancy.dto';
+import { ApiOperationOptionsWithSummary, ApiOperator } from '@src/common/types/common.type';
+
+export const ApiFancy: ApiOperator<keyof FancyController> = {
+  Create: (apiOperationOptions: ApiOperationOptionsWithSummary): PropertyDecorator => {
+    return applyDecorators(
+      ApiOperation({
+        ...apiOperationOptions
+      }),
+      ApiResponse({
+        status: 201,
+        description: 'Fancy 생성 성공.',
+        type: FancyDto,
+        schema: {
+          example: {
+            id: '90c7gRlwkLvmDQxbp5pzY',
+            name: 'finger ring',
+            costPrice: 25000,
+            price: 24250,
+            discountRate: 3,
+            description1: '예쁘고 미니멀한 반지',
+            description2: '이 반지는 예쁘고 미니멀한 반자입니다.',
+            status: 'ACTIVE',
+            createdAt: '2024-09-05T12:15:54.194Z',
+            updatedAt: '2024-09-05T12:15:54.194Z'
+          },
+          $ref: getSchemaPath(FancyDto)
+        }
+      })
+    );
+  }
+};

--- a/src/api/fancy/dtos/create-fancy.dto.ts
+++ b/src/api/fancy/dtos/create-fancy.dto.ts
@@ -1,4 +1,4 @@
-import { OmitType } from '@nestjs/swagger';
+import { ApiPropertyOptional, OmitType } from '@nestjs/swagger';
 
 import { FancyDto } from '@src/api/fancy/dtos/fancy.dto';
 

--- a/src/api/fancy/dtos/create-fancy.dto.ts
+++ b/src/api/fancy/dtos/create-fancy.dto.ts
@@ -1,4 +1,4 @@
-import { ApiPropertyOptional, OmitType } from '@nestjs/swagger';
+import { OmitType } from '@nestjs/swagger';
 
 import { FancyDto } from '@src/api/fancy/dtos/fancy.dto';
 

--- a/src/api/fancy/dtos/create-fancy.dto.ts
+++ b/src/api/fancy/dtos/create-fancy.dto.ts
@@ -1,0 +1,5 @@
+import { OmitType } from '@nestjs/swagger';
+
+import { FancyDto } from '@src/api/fancy/dtos/fancy.dto';
+
+export class CreateFancyDto extends OmitType(FancyDto, ['id', 'price', 'createdAt', 'updatedAt']) {}

--- a/src/api/fancy/dtos/fancy.dto.ts
+++ b/src/api/fancy/dtos/fancy.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 import { ProductStatus } from '@prisma/client';
-import { IsDate, IsEnum, IsInt, IsNotEmpty, IsNumber, IsString, Min } from 'class-validator';
+import { IsDate, IsEnum, IsInt, IsNotEmpty, IsString, Min } from 'class-validator';
 
 export class FancyDto {
   @ApiProperty({ description: '아이디', example: '90c7gRlwkLvmDQxbp5pzY' })
@@ -24,7 +24,7 @@ export class FancyDto {
   price: number;
 
   @ApiProperty({ description: '할인율', example: 3 })
-  @IsNumber()
+  @IsInt()
   @Min(0)
   discountRate: number;
 

--- a/src/api/fancy/dtos/fancy.dto.ts
+++ b/src/api/fancy/dtos/fancy.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 import { ProductStatus } from '@prisma/client';
-import { IsDate, IsEnum, IsNotEmpty, IsNumber, IsString, Min } from 'class-validator';
+import { IsDate, IsEnum, IsInt, IsNotEmpty, IsNumber, IsString, Min } from 'class-validator';
 
 export class FancyDto {
   @ApiProperty({ description: '아이디', example: '90c7gRlwkLvmDQxbp5pzY' })
@@ -14,12 +14,12 @@ export class FancyDto {
   name: string;
 
   @ApiProperty({ description: '원가', example: 25000 })
-  @IsNumber()
+  @IsInt()
   @Min(0)
   costPrice: number;
 
   @ApiProperty({ description: '가격', example: 24250 })
-  @IsNumber()
+  @IsInt()
   @Min(0)
   price: number;
 
@@ -31,12 +31,12 @@ export class FancyDto {
   @ApiProperty({ description: '설명1', example: '예쁘고 미니멀한 반지' })
   @IsString()
   @ApiPropertyOptional()
-  description1: string;
+  description1?: string;
 
   @ApiProperty({ description: '설명2', example: '이 반지는 예쁘고 미니멀한 반자입니다.' })
   @IsString()
   @ApiPropertyOptional()
-  description2: string;
+  description2?: string;
 
   @ApiProperty({ description: '상태', example: 'ACTIVE' })
   @IsEnum(ProductStatus)

--- a/src/api/fancy/dtos/fancy.dto.ts
+++ b/src/api/fancy/dtos/fancy.dto.ts
@@ -1,0 +1,37 @@
+import { ProductStatus } from '@prisma/client';
+import { IsDate, IsEnum, IsNotEmpty, IsNumber, IsString, Min } from 'class-validator';
+
+export class FancyDto {
+  id: string;
+
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsNumber()
+  @Min(0)
+  costPrice: number;
+
+  @IsNumber()
+  @Min(0)
+  price: number;
+
+  @IsNumber()
+  @Min(0)
+  discountRate: number;
+
+  @IsString()
+  description1: string;
+
+  @IsString()
+  description2: string;
+
+  @IsEnum(ProductStatus)
+  status: ProductStatus;
+
+  @IsDate()
+  createdAt: Date;
+
+  @IsDate()
+  updatedAt: Date;
+}

--- a/src/api/fancy/dtos/fancy.dto.ts
+++ b/src/api/fancy/dtos/fancy.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 import { ProductStatus } from '@prisma/client';
 import { IsDate, IsEnum, IsNotEmpty, IsNumber, IsString, Min } from 'class-validator';
@@ -30,10 +30,12 @@ export class FancyDto {
 
   @ApiProperty({ description: '설명1', example: '예쁘고 미니멀한 반지' })
   @IsString()
+  @ApiPropertyOptional()
   description1: string;
 
   @ApiProperty({ description: '설명2', example: '이 반지는 예쁘고 미니멀한 반자입니다.' })
   @IsString()
+  @ApiPropertyOptional()
   description2: string;
 
   @ApiProperty({ description: '상태', example: 'ACTIVE' })

--- a/src/api/fancy/dtos/fancy.dto.ts
+++ b/src/api/fancy/dtos/fancy.dto.ts
@@ -1,37 +1,50 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 import { ProductStatus } from '@prisma/client';
 import { IsDate, IsEnum, IsNotEmpty, IsNumber, IsString, Min } from 'class-validator';
 
 export class FancyDto {
+  @ApiProperty({ description: '아이디', example: '90c7gRlwkLvmDQxbp5pzY' })
+  @IsString()
   id: string;
 
+  @ApiProperty({ description: '이름', example: 'finger ring' })
   @IsString()
   @IsNotEmpty()
   name: string;
 
+  @ApiProperty({ description: '원가', example: 25000 })
   @IsNumber()
   @Min(0)
   costPrice: number;
 
+  @ApiProperty({ description: '가격', example: 24250 })
   @IsNumber()
   @Min(0)
   price: number;
 
+  @ApiProperty({ description: '할인율', example: 3 })
   @IsNumber()
   @Min(0)
   discountRate: number;
 
+  @ApiProperty({ description: '설명1', example: '예쁘고 미니멀한 반지' })
   @IsString()
   description1: string;
 
+  @ApiProperty({ description: '설명2', example: '이 반지는 예쁘고 미니멀한 반자입니다.' })
   @IsString()
   description2: string;
 
+  @ApiProperty({ description: '상태', example: 'ACTIVE' })
   @IsEnum(ProductStatus)
   status: ProductStatus;
 
+  @ApiProperty({ description: '생성일', example: '2024-09-05T12:15:54.194Z' })
   @IsDate()
   createdAt: Date;
 
+  @ApiProperty({ description: '수정일', example: '2024-09-05T12:15:54.194Z' })
   @IsDate()
   updatedAt: Date;
 }

--- a/src/api/fancy/fancy.module.ts
+++ b/src/api/fancy/fancy.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+
+import { FancyController } from '@src/api/fancy/controllers/fancy.controller';
+import { FancyRepository } from '@src/api/fancy/repositories/fancy.repository';
+import { FancyService } from '@src/api/fancy/services/fancy.service';
+
+@Module({
+  imports: [],
+  controllers: [FancyController],
+  providers: [FancyService, FancyRepository]
+})
+export class FancyModule {}

--- a/src/api/fancy/fancy.module.ts
+++ b/src/api/fancy/fancy.module.ts
@@ -1,12 +1,12 @@
 import { Module } from '@nestjs/common';
 
-import { FancyController } from '@src/api/fancy/controllers/fancy.controller';
+import { FancyAdminController } from '@src/api/fancy/controllers/fancy.admin.controller';
 import { FancyRepository } from '@src/api/fancy/repositories/fancy.repository';
 import { FancyService } from '@src/api/fancy/services/fancy.service';
 
 @Module({
   imports: [],
-  controllers: [FancyController],
+  controllers: [FancyAdminController],
   providers: [FancyService, FancyRepository]
 })
 export class FancyModule {}

--- a/src/api/fancy/repositories/fancy.repository.ts
+++ b/src/api/fancy/repositories/fancy.repository.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+
+import { Fancy, Prisma } from '@prisma/client';
+
+import { IFancyRepository } from '@src/api/fancy/repositories/i-fancy-repository.interface';
+import { PrismaService } from '@src/prisma/prisma.service';
+
+@Injectable()
+export class FancyRepository implements IFancyRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  create(data: Prisma.FancyCreateInput): Promise<Fancy> {
+    return this.prisma.fancy.create({ data });
+  }
+
+  findOne(data: any): Promise<any> {
+    return this.prisma.fancy.findFirst({ where: data });
+  }
+
+  update(data: any): Promise<any> {
+    return this.prisma.fancy.update({ where: { id: data.id }, data });
+  }
+}

--- a/src/api/fancy/repositories/i-fancy-repository.interface.ts
+++ b/src/api/fancy/repositories/i-fancy-repository.interface.ts
@@ -1,0 +1,7 @@
+import { Fancy, Prisma } from '@prisma/client';
+
+import { IRepository } from '@src/common/interfaces/i-repository.interface';
+
+export interface IFancyRepository extends IRepository {
+  create(data: Prisma.FancyCreateInput): Promise<Fancy>;
+}

--- a/src/api/fancy/services/fancy.service.ts
+++ b/src/api/fancy/services/fancy.service.ts
@@ -36,6 +36,7 @@ export class FancyService implements IFancyService {
   }
 
   private calculatePrice(costPrice: number, discountRate: number): number {
-    return costPrice * (1 - discountRate / 100);
+    const price = costPrice * (1 - discountRate / 100);
+    return Math.ceil(price);
   }
 }

--- a/src/api/fancy/services/fancy.service.ts
+++ b/src/api/fancy/services/fancy.service.ts
@@ -39,7 +39,7 @@ export class FancyService implements IFancyService {
     return data;
   }
 
-  delete(data: any): void {}
+  delete(): void {}
 
   private calculatePrice(costPrice: number, discountRate: number): number {
     const price = costPrice * (1 - discountRate / 100);

--- a/src/api/fancy/services/fancy.service.ts
+++ b/src/api/fancy/services/fancy.service.ts
@@ -1,0 +1,42 @@
+import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
+
+import { Fancy, Prisma } from '@prisma/client';
+import { nanoid } from 'nanoid';
+
+import { CreateFancyDto } from '@src/api/fancy/dtos/create-fancy.dto';
+import { FancyRepository } from '@src/api/fancy/repositories/fancy.repository';
+import { IFancyRepository } from '@src/api/fancy/repositories/i-fancy-repository.interface';
+
+import { IFancyService } from './i-fancy-service.interface';
+
+@Injectable()
+export class FancyService implements IFancyService {
+  constructor(@Inject(FancyRepository) private readonly fancyRepository: IFancyRepository) {}
+
+  async create(fancyData: CreateFancyDto): Promise<Fancy> {
+    try {
+      const id = nanoid();
+      const price = this.calculatePrice(fancyData.costPrice, fancyData.discountRate);
+      const createFancyData: Prisma.FancyCreateInput = { ...fancyData, id, price };
+
+      return this.fancyRepository.create(createFancyData);
+    } catch (error) {
+      console.error(error);
+      throw new HttpException('Failed to create fancy', HttpStatus.INTERNAL_SERVER_ERROR, {
+        cause: error
+      });
+    }
+  }
+
+  async findOne(data) {
+    return null;
+  }
+
+  async update(data) {
+    return null;
+  }
+
+  private calculatePrice(costPrice: number, discountRate: number): number {
+    return costPrice * (1 - discountRate / 100);
+  }
+}

--- a/src/api/fancy/services/fancy.service.ts
+++ b/src/api/fancy/services/fancy.service.ts
@@ -6,8 +6,7 @@ import { nanoid } from 'nanoid';
 import { CreateFancyDto } from '@src/api/fancy/dtos/create-fancy.dto';
 import { FancyRepository } from '@src/api/fancy/repositories/fancy.repository';
 import { IFancyRepository } from '@src/api/fancy/repositories/i-fancy-repository.interface';
-
-import { IFancyService } from './i-fancy-service.interface';
+import { IFancyService } from '@src/api/fancy/services/i-fancy-service.interface';
 
 @Injectable()
 export class FancyService implements IFancyService {
@@ -29,11 +28,11 @@ export class FancyService implements IFancyService {
   }
 
   async findOne(data) {
-    return null;
+    return data;
   }
 
   async update(data) {
-    return null;
+    return data;
   }
 
   private calculatePrice(costPrice: number, discountRate: number): number {

--- a/src/api/fancy/services/fancy.service.ts
+++ b/src/api/fancy/services/fancy.service.ts
@@ -31,9 +31,15 @@ export class FancyService implements IFancyService {
     return data;
   }
 
+  async findAll() {
+    return [];
+  }
+
   async update(data) {
     return data;
   }
+
+  delete(data: any): void {}
 
   private calculatePrice(costPrice: number, discountRate: number): number {
     const price = costPrice * (1 - discountRate / 100);

--- a/src/api/fancy/services/i-fancy-service.interface.ts
+++ b/src/api/fancy/services/i-fancy-service.interface.ts
@@ -1,8 +1,8 @@
 import { Fancy } from '@prisma/client';
 
 import { CreateFancyDto } from '@src/api/fancy/dtos/create-fancy.dto';
-import { IRepository } from '@src/common/interfaces/i-repository.interface';
+import { IService } from '@src/common/interfaces/i-service.interface';
 
-export interface IFancyService extends IRepository {
+export interface IFancyService extends IService {
   create(fancyData: CreateFancyDto): Promise<Fancy>;
 }

--- a/src/api/fancy/services/i-fancy-service.interface.ts
+++ b/src/api/fancy/services/i-fancy-service.interface.ts
@@ -1,0 +1,8 @@
+import { Fancy } from '@prisma/client';
+
+import { CreateFancyDto } from '@src/api/fancy/dtos/create-fancy.dto';
+import { IRepository } from '@src/common/interfaces/i-repository.interface';
+
+export interface IFancyService extends IRepository {
+  create(fancyData: CreateFancyDto): Promise<Fancy>;
+}

--- a/src/common/interfaces/i-service.interface.ts
+++ b/src/common/interfaces/i-service.interface.ts
@@ -3,5 +3,5 @@ export interface IService {
   findAll: () => void;
   findOne: (data: any) => Promise<any>;
   update: (data: any) => Promise<any>;
-  delete: () => void;
+  delete: (data: any) => void;
 }


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
fancy 제품 생성 API 밎 swagger 문서 작성했습니다.
<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
fancy의 id를 생성하기 위해 [nanoid](https://github.com/ai/nanoid?tab=readme-ov-file#readme)를 사용합니다.
[fancy.service.ts line 17](https://github.com/fashion24-developer/fashion24-back/pull/36/files#diff-ce12a8d15e746d9d743a88015ca0ad9260715e2bcf374599673f3b2af2e961b3R17)

유저의 권한을 확인하기 위해 [`AdminGuard`](https://github.com/fashion24-developer/fashion24-back/pull/36/files#diff-d21c105c29dd68639c276bdd5ca0d50872d1f27247921cd4d4d09823ecb9ab23R81-R120)를 추가했습니다.

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#35 

<!-- 작업한 API (선택) -->
### API

| Method | Path      | 설명           | 작업(추가, 수정, 삭제) |
| ------ | --------- | -------------- | ---------------------- |
| POST    | /api/fancy | fancy 생성 | 추가                   |
