### PR TITLE
doc(#37): fancy create api 에러 케이스 문서 추가

### DIFF
--- a/src/api/fancy/controllers/fancy.swagger.ts
+++ b/src/api/fancy/controllers/fancy.swagger.ts
@@ -2,8 +2,6 @@ import { applyDecorators } from '@nestjs/common';
 import { ApiCookieAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { getSchemaPath } from '@nestjs/swagger';
 
-import path from 'path';
-
 import { FancyAdminController } from '@src/api/fancy/controllers/fancy.admin.controller';
 import { FancyDto } from '@src/api/fancy/dtos/fancy.dto';
 import { ApiOperationOptionsWithSummary, ApiOperator } from '@src/common/types/common.type';

--- a/src/api/fancy/controllers/fancy.swagger.ts
+++ b/src/api/fancy/controllers/fancy.swagger.ts
@@ -2,6 +2,8 @@ import { applyDecorators } from '@nestjs/common';
 import { ApiCookieAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { getSchemaPath } from '@nestjs/swagger';
 
+import path from 'path';
+
 import { FancyAdminController } from '@src/api/fancy/controllers/fancy.admin.controller';
 import { FancyDto } from '@src/api/fancy/dtos/fancy.dto';
 import { ApiOperationOptionsWithSummary, ApiOperator } from '@src/common/types/common.type';
@@ -68,6 +70,31 @@ export const ApiFancy: ApiOperator<keyof FancyAdminController> = {
             error: {
               type: 'string',
               example: 'Bad Request'
+            }
+          }
+        }
+      }),
+      ApiResponse({
+        status: 403,
+        description: 'admin 권한이 없는 경우',
+        schema: {
+          type: 'object',
+          properties: {
+            statusCode: {
+              type: 'number',
+              example: 403
+            },
+            timestamp: {
+              type: 'string',
+              example: '2024-09-06T05:02:18.503Z'
+            },
+            path: {
+              type: 'string',
+              example: '/api/admin/fancy'
+            },
+            message: {
+              type: 'string',
+              example: `You don't have permission to access this resource`
             }
           }
         }


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
fancy create api에서 admin 권한이 없을 떄의 에러 메시지를 swagger 문서에 추가했습니다.
<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#37
