### PR TITLE
✏️ modify(#52): jwt auth guard에서 토큰 header에서 받을 수 있도록 수정

### DIFF
--- a/src/api/auth/jwt/jwt-auth.guard.ts
+++ b/src/api/auth/jwt/jwt-auth.guard.ts
@@ -10,7 +10,13 @@ import { COMMON_ERROR_HTTP_STATUS_MESSAGE } from '@src/common/constants/common.c
 export class AccessTokenAuthGuard extends AuthGuard('accessToken') {
   canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
     const request = context.switchToHttp().getRequest();
-    const accessToken = request.cookies['accessToken'];
+    /**
+     * @todo 배포 시 cookie에서만 가져오도록 수정
+     */
+    // const accessToken = request.cookies['accessToken'];
+    const accessToken =
+      request.cookies['accessToken'] || request.headers['authorization']?.split(' ')[1];
+
     if (!accessToken) {
       throw new HttpException('jwt must be provided', HttpStatus.BAD_REQUEST);
     }
@@ -45,7 +51,13 @@ export class AccessTokenAuthGuard extends AuthGuard('accessToken') {
 export class RefreshTokenAuthGuard extends AuthGuard('refreshToken') {
   canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
     const request = context.switchToHttp().getRequest();
-    const refreshToken = request.cookies['refreshToken'];
+    /**
+     * @todo 배포 시 cookie에서만 가져오도록 수정
+     */
+    // const refreshToken = request.cookies['refreshToken'];
+    const refreshToken =
+      request.cookies['refreshToken'] || request.headers['authorization']?.split(' ')[1];
+
     if (!refreshToken) {
       throw new HttpException(
         {
@@ -104,7 +116,12 @@ export class AccessTokenOptionalAuthGuard extends AuthGuard('accessToken') {}
 export class AdminGuard extends AuthGuard('accessToken') {
   canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
     const request = context.switchToHttp().getRequest();
-    const accessToken = request.cookies['accessToken'];
+    /**
+     * @todo 배포 시 cookie에서만 가져오도록 수정
+     */
+    // const accessToken = request.cookies['accessToken'];
+    const accessToken =
+      request.cookies['accessToken'] || request.headers['authorization']?.split(' ')[1];
     if (!accessToken) {
       throw new HttpException('jwt must be provided', HttpStatus.BAD_REQUEST);
     }

--- a/src/api/auth/jwt/jwt.strategy.ts
+++ b/src/api/auth/jwt/jwt.strategy.ts
@@ -16,7 +16,13 @@ export class AccessTokenStrategy extends PassportStrategy(Strategy, 'accessToken
     private readonly appConfigService: AppConfigService
   ) {
     super({
-      jwtFromRequest: (req) => req.cookies['accessToken'],
+      /**
+       * @todo 배포 시 cookie에서만 가져오도록 수정
+       */
+      // jwtFromRequest: (req) => req.cookies['accessToken'],
+      jwtFromRequest: (req) => {
+        return req.cookies['accessToken'] || req.headers['authorization']?.split(' ')[1];
+      },
       ignoreExpiration: false,
       secretOrKey: appConfigService.get<string>(ENV_KEY.ACCESS_TOKEN_SECRET_KEY),
       passReqToCallback: true
@@ -35,7 +41,12 @@ export class AccessTokenStrategy extends PassportStrategy(Strategy, 'accessToken
       );
     }
 
-    const tokenFromRequest = request.cookies['accessToken'];
+    /**
+     * @todo 배포 시 cookie에서만 가져오도록 수정
+     */
+    // const tokenFromRequest = request.cookies['accessToken'];
+    const tokenFromRequest =
+      request.cookies['accessToken'] || request.headers['authorization']?.split(' ')[1];
     const tokenInRedis = await this.redisService.get(`${payload.userId}-accessToken`);
 
     if (!tokenInRedis) {
@@ -72,7 +83,13 @@ export class RefreshTokenStrategy extends PassportStrategy(Strategy, 'refreshTok
     private readonly appConfigService: AppConfigService
   ) {
     super({
-      jwtFromRequest: (req) => req.cookies['refreshToken'],
+      /**
+       * @todo 배포 시 cookie에서만 가져오도록 수정
+       */
+      // jwtFromRequest: (req) => req.cookies['refreshToken'],
+      jwtFromRequest: (req) => {
+        return req.cookies['refreshToken'] || req.headers['authorization']?.split(' ')[1];
+      },
       ignoreExpiration: false,
       secretOrKey: appConfigService.get<string>(ENV_KEY.REFRESH_TOKEN_SECRET_KEY),
       passReqToCallback: true
@@ -91,7 +108,12 @@ export class RefreshTokenStrategy extends PassportStrategy(Strategy, 'refreshTok
       );
     }
 
-    const tokenFromRequest = request.cookies['refreshToken'];
+    /**
+     * @todo 배포 시 cookie에서만 가져오도록 수정
+     */
+    // const tokenFromRequest = request.cookies['refreshToken'];
+    const tokenFromRequest =
+      request.cookies['refreshToken'] || request.headers['authorization']?.split(' ')[1];
     const tokenInRedis = await this.redisService.get(`${payload.userId}-refreshToken`);
 
     if (!tokenInRedis) {

--- a/src/api/auth/repositories/token.repository.ts
+++ b/src/api/auth/repositories/token.repository.ts
@@ -17,7 +17,7 @@ export class TokenRepository implements ITokenRepository {
     return;
   }
 
-  findAll(data: any): Promise<any> {
+  findAll(): Promise<any> {
     return;
   }
 


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
jwt auth guard에서 토큰 header에서 받을 수 있도록 수정
<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
토큰을 cookie, header 둘 다 받을 수 있도록 로직을 수정했습니다.

기존처럼 swagger에서는 쿠키로, 프론트 개발환경에서는 헤더로 사용할 수 있도록 하기 위함입니다.

추후에 쿠키로 토큰을 받는게 가능해지면 추가된 코드는 지우고, 주석처리된 코드 주석 풀면 됩니다.
<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#52