### PR TITLE
🐞 bugfix(#75): 소셜 토큰 저장할때 upsert 메서드 사용 (로우 있으면 수정, 없으면 추가)

### DIFF
--- a/src/api/apps/auth/repositories/token.repository.ts
+++ b/src/api/apps/auth/repositories/token.repository.ts
@@ -9,8 +9,13 @@ export class TokenRepository implements ITokenRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async create(data: UserTokenEntity): Promise<UserTokenEntity> {
-    const record = await this.prisma.userToken.create({
-      data: {
+    const record = await this.prisma.userToken.upsert({
+      where: { userId: data.userId },
+      update: {
+        socialAccessToken: data.socialAccessToken,
+        socialRefreshToken: data.socialRefreshToken
+      },
+      create: {
         userId: data.userId,
         socialAccessToken: data.socialAccessToken,
         socialRefreshToken: data.socialRefreshToken


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
로그인 할 때 소셜 토큰을 DB에 저장하는 과정에서 토큰을 create메서드를 사용하여 저장해서 유저가 로그아웃을 하지 않고 다시 로그인 요청을 보내면 소셜토큰이 이미 저장되어 있어 에러가 발생하는 문제를 prisma upsert메서드를 사용하여 해결했습니다.
<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#75 

<!-- 작업한 API (선택) -->
### API

| Method | Path      | 설명           | 작업(추가, 수정, 삭제) |
| ------ | --------- | -------------- | ---------------------- |
| POST    | /api/v1/auth/{provider}/login | 소셜 로그인 | 수정                   |
