### PR TITLE
Modify/#78/get social user info

### DIFF
--- a/prisma/migrations/20241011081321_add_user_gender_enum/migration.sql
+++ b/prisma/migrations/20241011081321_add_user_gender_enum/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - The `gender` column on the `user` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- CreateEnum
+CREATE TYPE "GENDER" AS ENUM ('MALE', 'FEMALE', 'UNKNOWN');
+
+-- AlterTable
+ALTER TABLE "user" DROP COLUMN "gender",
+ADD COLUMN     "gender" "GENDER" NOT NULL DEFAULT 'UNKNOWN';

--- a/prisma/migrations/20241011094310_modify_birth_column_type/migration.sql
+++ b/prisma/migrations/20241011094310_modify_birth_column_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user" ALTER COLUMN "birth" SET DATA TYPE DATE;

--- a/prisma/migrations/20241014112131_modify_user_social_refresh_token_to_nullable/migration.sql
+++ b/prisma/migrations/20241014112131_modify_user_social_refresh_token_to_nullable/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user_token" ALTER COLUMN "social_refresh_token" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,9 +55,9 @@ model User {
   /// 주소
   address  String?   @db.VarChar(255)
   /// 성별
-  gender   Boolean?  @db.Boolean
+  gender   GENDER    @default(UNKNOWN)
   /// 생년월일
-  birth    DateTime?
+  birth    DateTime? @db.Date
 
   /// 가입일
   createdAt DateTime @default(now()) @map("created_at")
@@ -767,6 +767,12 @@ enum Provider {
   naver
   kakao
   google
+}
+
+enum GENDER {
+  MALE
+  FEMALE
+  UNKNOWN
 }
 
 /// 상품 상태 ENUM

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,13 +78,13 @@ model User {
 /// 유저 토큰 테이블
 model UserToken {
   /// Primary Key
-  id                 Int    @id @default(autoincrement())
+  id                 Int     @id @default(autoincrement())
   /// 유저 아이디 (FK)
-  userId             Int    @unique @map("user_id")
+  userId             Int     @unique @map("user_id")
   /// 소셜 액세스 토큰
-  socialAccessToken  String @unique @map("social_access_token") @db.VarChar(255)
+  socialAccessToken  String  @unique @map("social_access_token") @db.VarChar(255)
   /// 소셜 리프레시 토큰
-  socialRefreshToken String @unique @map("social_refresh_token") @db.VarChar(255)
+  socialRefreshToken String? @unique @map("social_refresh_token") @db.VarChar(255)
 
   /// 생성일
   createdAt DateTime @default(now()) @map("created_at")

--- a/src/api/apps/auth/auth-provider-config.ts
+++ b/src/api/apps/auth/auth-provider-config.ts
@@ -50,9 +50,10 @@ export function createAuthProviderConfig() {
         Authorization: `Bearer ${socialAccessToken}`
       }),
       extractUserInfo: (userInfoResponse: any) => ({
-        uniqueId: userInfoResponse.response.id,
-        nickname: userInfoResponse.response.name,
-        email: userInfoResponse.response.email,
+        uniqueId: String(userInfoResponse.id),
+        name: userInfoResponse.kakao_account.name,
+        email: userInfoResponse.kakao_account.email,
+        phone: userInfoResponse.kakao_account.phone_number,
         provider: UserProvider.KAKAO
       }),
       logoutUrl: 'https://kapi.kakao.com/v1/user/logout',

--- a/src/api/apps/auth/auth-provider-config.ts
+++ b/src/api/apps/auth/auth-provider-config.ts
@@ -79,7 +79,6 @@ export function createAuthProviderConfig() {
       }),
       extractUserInfo: (userInfoResponse: any) => ({
         uniqueId: userInfoResponse.id,
-        nickname: userInfoResponse.name,
         email: userInfoResponse.email,
         provider: UserProvider.GOOGLE
       })

--- a/src/api/apps/auth/auth-provider-config.ts
+++ b/src/api/apps/auth/auth-provider-config.ts
@@ -28,7 +28,7 @@ export function createAuthProviderConfig() {
       }),
       extractUserInfo: (userInfoResponse: any) => ({
         uniqueId: userInfoResponse.response.id,
-        nickname: userInfoResponse.response.nickname,
+        name: userInfoResponse.response.name,
         email: userInfoResponse.response.email,
         phone: userInfoResponse.response.mobile,
         provider: UserProvider.NAVER

--- a/src/api/apps/users/dtos/create-user.dto.ts
+++ b/src/api/apps/users/dtos/create-user.dto.ts
@@ -2,4 +2,4 @@ import { OmitType } from '@nestjs/mapped-types';
 
 import { UserInfoDto } from '@src/api/apps/users/dtos/user-info.dto';
 
-export class CreateUserDto extends OmitType(UserInfoDto, ['createdAt', 'updatedAt', 'deletedAt']) {}
+export class CreateUserDto extends OmitType(UserInfoDto, ['createdAt', 'updatedAt']) {}

--- a/src/api/apps/users/dtos/social-user-info.dto.ts
+++ b/src/api/apps/users/dtos/social-user-info.dto.ts
@@ -7,6 +7,5 @@ export class SocialUserInfoDto extends OmitType(UserInfoDto, [
   'point',
   'role',
   'createdAt',
-  'updatedAt',
-  'deletedAt'
+  'updatedAt'
 ]) {}

--- a/src/api/apps/users/dtos/user-info.dto.ts
+++ b/src/api/apps/users/dtos/user-info.dto.ts
@@ -9,6 +9,7 @@ import {
   IsString
 } from 'class-validator';
 
+import { UserGender } from '@src/api/apps/users/enums/user-gender.enum';
 import { UserProvider } from '@src/api/apps/users/enums/user-provider.enum';
 import { UserRole } from '@src/api/apps/users/enums/user-role.enum';
 import { ValueOf } from '@src/common/types/common.type';
@@ -24,7 +25,11 @@ export class UserInfoDto {
 
   @IsNotEmpty()
   @IsString()
-  nickname: string;
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  nickname?: string;
 
   @IsNotEmpty()
   @IsEmail()
@@ -50,6 +55,18 @@ export class UserInfoDto {
   @IsNumber()
   point: number = 0;
 
+  @IsOptional()
+  @IsString()
+  address?: string;
+
+  @IsNotEmpty()
+  @IsEnum(UserGender)
+  gender: ValueOf<typeof UserGender> = UserGender.UNKNOWN;
+
+  @IsOptional()
+  @IsDateString()
+  birth?: Date;
+
   @IsNotEmpty()
   @IsDateString()
   createdAt: Date;
@@ -57,7 +74,4 @@ export class UserInfoDto {
   @IsNotEmpty()
   @IsDateString()
   updatedAt: Date;
-
-  @IsDateString()
-  deletedAt?: Date;
 }

--- a/src/api/apps/users/entities/user.entity.ts
+++ b/src/api/apps/users/entities/user.entity.ts
@@ -1,18 +1,24 @@
+import { UserGender } from '@src/api/apps/users/enums/user-gender.enum';
 import { UserProvider } from '@src/api/apps/users/enums/user-provider.enum';
 import { UserRole } from '@src/api/apps/users/enums/user-role.enum';
 import { ValueOf } from '@src/common/types/common.type';
 
 interface UserCreateProps {
-  nickname: string;
+  name: string;
+  nickname?: string | null;
   email: string;
   phone?: string | null;
   provider: ValueOf<typeof UserProvider>;
   uniqueId: string;
+  address?: string | null;
+  gender: ValueOf<typeof UserGender>;
+  birth?: Date | null;
 }
 
 export class UserEntity {
   private readonly _id?: number;
-  private _nickname: string;
+  private _name: string;
+  private _nickname: string | null;
   private _email: string;
   private _phone: string | null;
   private _rank: number;
@@ -20,15 +26,21 @@ export class UserEntity {
   private _provider: ValueOf<typeof UserProvider>;
   private _role: ValueOf<typeof UserRole>;
   private readonly _uniqueId: string;
+  private _address: string | null;
+  private _gender: ValueOf<typeof UserGender>;
+  private _birth: Date | null;
   private readonly _createdAt: Date;
   private _updatedAt: Date;
-  private _deletedAt: Date | null;
 
   get id(): number | undefined {
     return this._id;
   }
 
-  get nickname(): string {
+  get name(): string {
+    return this._name;
+  }
+
+  get nickname(): string | null {
     return this._nickname;
   }
 
@@ -60,6 +72,18 @@ export class UserEntity {
     return this._point;
   }
 
+  get address(): string | null {
+    return this._address;
+  }
+
+  get gender(): ValueOf<typeof UserGender> {
+    return this._gender;
+  }
+
+  get birth(): Date | null {
+    return this._birth;
+  }
+
   get createdAt(): Date {
     return this._createdAt;
   }
@@ -68,13 +92,10 @@ export class UserEntity {
     return this._updatedAt;
   }
 
-  get deletedAt(): Date | null {
-    return this._deletedAt;
-  }
-
   getProps(): {
     id: number;
-    nickname: string;
+    name: string;
+    nickname: string | null;
     email: string;
     phone: string | null;
     rank: number;
@@ -82,12 +103,15 @@ export class UserEntity {
     role: ValueOf<typeof UserRole>;
     uniqueId: string;
     point: number;
+    address: string | null;
+    gender: ValueOf<typeof UserGender>;
+    birth: Date | null;
     createdAt: Date;
     updatedAt: Date;
-    deletedAt: Date | null;
   } {
     return {
       id: this._id,
+      name: this._name,
       nickname: this._nickname,
       email: this._email,
       phone: this._phone,
@@ -96,16 +120,32 @@ export class UserEntity {
       role: this._role,
       uniqueId: this._uniqueId,
       point: this._point,
+      address: this._address,
+      gender: this._gender,
+      birth: this._birth,
       createdAt: this._createdAt,
-      updatedAt: this._updatedAt,
-      deletedAt: this._deletedAt
+      updatedAt: this._updatedAt
     };
   }
 
   update(
-    props: Partial<Pick<UserEntity, 'rank' | 'email' | 'nickname' | 'phone' | 'point' | 'role'>>
+    props: Partial<
+      Pick<
+        UserEntity,
+        | 'rank'
+        | 'email'
+        | 'nickname'
+        | 'phone'
+        | 'point'
+        | 'role'
+        | 'address'
+        | 'gender'
+        | 'birth'
+        | 'name'
+      >
+    >
   ) {
-    const { rank, point, role, email, nickname, phone } = props;
+    const { rank, point, role, email, nickname, phone, name, address, gender, birth } = props;
 
     const now = new Date();
 
@@ -138,24 +178,49 @@ export class UserEntity {
       this._email = email;
       this._updatedAt = now;
     }
+
+    if (name) {
+      this._name = name;
+      this._updatedAt = now;
+    }
+
+    if (address) {
+      this._address = address;
+      this._updatedAt = now;
+    }
+
+    if (gender) {
+      this._gender = gender;
+      this._updatedAt = now;
+    }
+
+    if (birth) {
+      this._birth = birth;
+      this._updatedAt = now;
+    }
   }
 
   static create(createProps: UserCreateProps): UserEntity {
     return new UserEntity({
-      nickname: createProps.nickname,
+      name: createProps.name,
+      nickname: createProps.nickname || null,
       email: createProps.email,
       phone: createProps.phone || null,
       rank: 1,
       point: 0,
       provider: createProps.provider,
       role: UserRole.USER,
-      uniqueId: createProps.uniqueId
+      uniqueId: createProps.uniqueId,
+      address: createProps.address || null,
+      gender: createProps.gender,
+      birth: createProps.birth || null
     });
   }
 
   constructor(props: {
     id?: number;
-    nickname: string;
+    name: string;
+    nickname: string | null;
     email: string;
     phone: string | null;
     rank: number;
@@ -163,12 +228,15 @@ export class UserEntity {
     provider: ValueOf<typeof UserProvider>;
     role: ValueOf<typeof UserRole>;
     uniqueId: string;
+    address: string | null;
+    gender: ValueOf<typeof UserGender>;
+    birth: Date | null;
     createdAt?: Date;
     updatedAt?: Date;
-    deletedAt?: Date | null;
   }) {
     const {
       id,
+      name,
       nickname,
       email,
       phone,
@@ -178,13 +246,13 @@ export class UserEntity {
       role,
       uniqueId,
       createdAt,
-      updatedAt,
-      deletedAt
+      updatedAt
     } = props;
 
     const now = new Date();
 
     this._id = id || undefined;
+    this._name = name;
     this._nickname = nickname;
     this._email = email;
     this._phone = phone;
@@ -195,6 +263,5 @@ export class UserEntity {
     this._uniqueId = uniqueId;
     this._createdAt = createdAt || now;
     this._updatedAt = updatedAt || now;
-    this._deletedAt = deletedAt || null;
   }
 }

--- a/src/api/apps/users/enums/user-gender.enum.ts
+++ b/src/api/apps/users/enums/user-gender.enum.ts
@@ -1,0 +1,5 @@
+export const UserGender = {
+  MALE: 'MALE',
+  FEMALE: 'FEMALE',
+  UNKNOWN: 'UNKNOWN'
+} as const;

--- a/src/api/apps/users/repositories/users.repository.ts
+++ b/src/api/apps/users/repositories/users.repository.ts
@@ -9,7 +9,7 @@ export class UsersRepository implements IUsersRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async create(data: UserEntity): Promise<UserEntity> {
-    const record = await this.prisma.user.create({ data });
+    const record = await this.prisma.user.create({ data: data.getProps() });
 
     return new UserEntity(record);
   }
@@ -22,6 +22,10 @@ export class UsersRepository implements IUsersRepository {
 
   async findOneByUniqueId(uniqueId: string): Promise<UserEntity | null> {
     const record = await this.prisma.user.findUnique({ where: { uniqueId } });
+
+    if (!record) {
+      return null;
+    }
 
     return new UserEntity(record);
   }


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
소셜 로그인에서 가져올 유저 정보가 변경됨에 따라 코드를 수정했습니다.
<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
네이버 : 이름 (필수), 이메일 주소 (필수), 휴대폰 번호 (선택)
카카오 : 이름 (필수), 이메일 주소 (필수), 휴대폰 번호 (선택)
구글 : 이메일 주소 (필수)

구글의 경우, 유저의 본명이 저장되지 않고, 휴대폰 번호는 비공개로 설정하면 가져올 수 없어서 과감히 제거했습니다.

성별을 Boolean 타입에서 GENDER enum을 추가하여 타입을 변경했습니다.
GENDER enum에 들어갈 수 있는 값은 'MALE', 'FEMALE', 'UNKNOWN' 입니다.

생일(birth) 모델의 타입을 Timestamp에서 Date로 변경했습니다.
<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#78 

<!-- 작업한 API (선택) -->
### API

| Method | Path      | 설명           | 작업(추가, 수정, 삭제) |
| ------ | --------- | -------------- | ---------------------- |
| POST    | /api/v1/auth/{provider}/login | 소셜 로그인 | 수정                   |
